### PR TITLE
Fix login flow with simple fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,21 +207,30 @@
         <div class="form-group">
           <label class="form-label" for="login-password">Contraseña</label>
           <div class="password-input-container">
-            <input type="password" class="form-control" id="login-password" placeholder="Ingrese su contraseña" aria-describedby="password-error" readonly>
+            <input type="password" class="form-control" id="login-password" placeholder="Ingrese su contraseña" aria-describedby="password-error">
             <button type="button" class="password-toggle" id="login-password-toggle">
               <i class="fas fa-eye"></i>
             </button>
           </div>
           <div class="error-message" id="password-error">Contraseña incorrecta.</div>
         </div>
-        
+
         <div class="form-group">
           <label class="form-label" for="login-code">Código de Verificación (20 dígitos)</label>
-          <input type="password" class="form-control" id="login-code" placeholder="Código enviado a su correo electrónico" aria-describedby="code-error" readonly>
+          <input type="password" class="form-control" id="login-code" placeholder="Código enviado a su correo electrónico" aria-describedby="code-error">
           <div class="error-message" id="code-error">El código debe tener 20 dígitos.</div>
         </div>
-        
-        <!-- Slide to Unlock Button -->
+
+        <!-- Botón de login tradicional -->
+        <button type="submit" class="btn btn-primary" id="traditional-login-btn" style="margin-top: 1rem;">
+          <i class="fas fa-sign-in-alt"></i> Iniciar Sesión
+        </button>
+
+        <div style="text-align: center; margin: 1rem 0; font-size: 0.8rem; color: #666;">
+          O desliza el botón de abajo para acceder
+        </div>
+
+        <!-- Slide to Unlock Button (mantener existente) -->
         <div class="slide-to-unlock-container">
           <div class="slide-to-unlock" id="slide-to-unlock">
             <div class="slide-track">


### PR DESCRIPTION
## Summary
- make login fields editable and add manual login button
- add simple login functionality and proceed helper
- hook new login button to traditional login
- expose bypass login helper for dev debugging

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6851ead9e4008324a4f5edad431a5a81