### PR TITLE
Add Zelle and US account buttons

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -3402,12 +3402,17 @@
             <i class="fas fa-history"></i> Transacciones Recientes
             <a href="#" id="view-all-transactions">Ver todas</a>
           </div>
-          
+
           <div class="transaction-list" id="recent-transactions">
             <!-- Will be populated by JavaScript -->
           </div>
         </div>
-        
+
+        <div style="margin-top: 1rem; display: flex; flex-direction: column; gap: 0.75rem;">
+          <button class="btn btn-primary" id="create-zelle-account-btn">Crear y activar mi cuenta Zelle</button>
+          <button class="btn btn-primary" id="us-account-btn">Mi cuenta en USA</button>
+        </div>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add buttons for creating a Zelle account and US account below recent transactions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68529cbc4be88324b5bfd9a9ce684df4