### PR TITLE
Implement AJAX transfer overlay

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -7419,7 +7419,7 @@ function updateVerificationProcessingBanner() {
         });
       }
       
-      // Send button - redirige a transferencia.html y comparte datos via sessionStorage
+      // Send button - carga transferencia via AJAX y comparte datos via sessionStorage
       document.querySelectorAll('#send-btn, #success-transfer').forEach(btn => {
         if (btn) {
           btn.addEventListener('click', function(e) {
@@ -7427,13 +7427,17 @@ function updateVerificationProcessingBanner() {
               showToast('error', 'Fondos Insuficientes', 'No tiene fondos suficientes para realizar una transferencia. Por favor recargue su cuenta primero.');
               return;
             }
-            
+
             // Guardar información necesaria en sessionStorage para compartir con transferencia.html
             saveDataForTransfer();
-            
-            // Redirigir a la página de transferencia
-            window.location.href = 'transferencia.html';
-            
+
+            // Cargar la página de transferencia sin recargar
+            if (typeof loadTransferPage === 'function') {
+              loadTransferPage();
+            } else {
+              window.location.href = 'transferencia.html';
+            }
+
             // Reset inactivity timer
             resetInactivityTimer();
           });
@@ -9074,5 +9078,8 @@ function updateVerificationProcessingBanner() {
     // Llamar a esto asegura que todos los valores estén actualizados según la tasa central
     updateExchangeRate(CONFIG.EXCHANGE_RATES.USD_TO_BS);
   </script>
+
+  <div id="transfer-overlay" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:#fff; z-index:10000;"></div>
+  <script src="spa.js"></script>
 </body>
 </html>

--- a/spa.js
+++ b/spa.js
@@ -1,0 +1,37 @@
+function loadTransferPage() {
+  fetch('transferencia.html')
+    .then(res => res.text())
+    .then(html => {
+      const overlay = document.getElementById('transfer-overlay');
+      if (!overlay) return;
+      overlay.innerHTML = '<button id="close-transfer" class="close-transfer">×</button><iframe id="transfer-frame" frameborder="0"></iframe>';
+      const frame = document.getElementById('transfer-frame');
+      frame.srcdoc = html;
+      frame.style.width = '100%';
+      frame.style.height = '100%';
+      overlay.style.display = 'block';
+      history.pushState({page:'transferencia'}, '', 'transferencia.html');
+      document.getElementById('close-transfer').addEventListener('click', function(){
+        history.back();
+      });
+    });
+}
+
+window.addEventListener('popstate', function(event){
+  const overlay = document.getElementById('transfer-overlay');
+  if (!overlay) return;
+  if (overlay.style.display === 'block') {
+    overlay.style.display = 'none';
+    overlay.innerHTML = '';
+  }
+});
+
+// Minimal styles for overlay and close button
+const style = document.createElement('style');
+style.textContent = `
+  #transfer-overlay { backdrop-filter: blur(2px); }
+  #transfer-overlay .close-transfer {
+    position:absolute; top:10px; right:10px; z-index:10001; background:#fff; border:none; font-size:24px; cursor:pointer;
+  }
+`;
+document.head.appendChild(style);


### PR DESCRIPTION
## Summary
- load transfer page via AJAX overlay
- modify send button to open overlay instead of redirect
- expose minimal overlay script

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852b6125ee08324a7518f653184d67b