### PR TITLE
Fix session sharing and exchange rate

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -4821,12 +4821,6 @@
       // Storage event listener para sincronizar múltiples pestañas
       window.addEventListener('storage', handleStorageChange);
       
-      // Before unload handler
-      window.addEventListener('beforeunload', function() {
-        // Eliminar datos de sesión, mantener solo el balance
-        clearSessionData();
-      });
-      
       // Check for returning from transfer.html
       checkReturnFromTransfer();
       
@@ -5139,6 +5133,28 @@ function updateVerificationProcessingBanner() {
 
     // Verificar si regresa de transferencia.html y procesar la información
     function checkReturnFromTransfer() {
+  const pendingJson = sessionStorage.getItem("remeexPendingTransactions");
+  if (pendingJson) {
+    try {
+      const list = JSON.parse(pendingJson);
+      list.forEach(tx => {
+        if (!currentUser.transactions.some(t => t.reference === tx.id)) {
+          const amountUsd = tx.method === "international" ? parseFloat(tx.amount) : parseFloat(tx.amount) / CONFIG.EXCHANGE_RATES.USD_TO_BS;
+          addTransaction({
+            type: "withdraw",
+            reference: tx.id,
+            amount: amountUsd,
+            amountBs: amountUsd * CONFIG.EXCHANGE_RATES.USD_TO_BS,
+            amountEur: amountUsd * CONFIG.EXCHANGE_RATES.USD_TO_EUR,
+            date: getCurrentDateTime(),
+            description: tx.method === "mobile" ? "Retiro a Pago Móvil" : (tx.method === "bank" ? `Retiro a ${tx.bankName}` : `Retiro Internacional - ${tx.bankName}`),
+            status: "pending",
+            destination: tx.destination
+          });
+        }
+      });
+    } catch(e) { console.error("Error processing pending transactions from session:", e); }
+  }
       const transferData = JSON.parse(sessionStorage.getItem(CONFIG.STORAGE_KEYS.TRANSFER_DATA) || 'null');
       
       if (transferData) {
@@ -5801,7 +5817,7 @@ function updateVerificationProcessingBanner() {
       sessionStorage.setItem(CONFIG.SESSION_KEYS.BALANCE, JSON.stringify(currentUser.balance));
       
       // Guardar tasa de cambio actual
-      sessionStorage.setItem(CONFIG.SESSION_KEYS.EXCHANGE_RATE, CONFIG.EXCHANGE_RATES.USD_TO_BS.toString());
+      sessionStorage.setItem(CONFIG.SESSION_KEYS.EXCHANGE_RATE, JSON.stringify(CONFIG.EXCHANGE_RATES));
       
       // Guardar ID del dispositivo
       sessionStorage.setItem('remeexDeviceId', currentUser.deviceId);

--- a/transferencia.html
+++ b/transferencia.html
@@ -4433,14 +4433,19 @@
           verificationInProgress = verificationStatus === 'in_progress';
         }
         
-        // Recuperar tasa de cambio
         const exchangeRateJson = sessionStorage.getItem(STORAGE_KEYS.EXCHANGE_RATE);
         if (exchangeRateJson) {
-          const rates = JSON.parse(exchangeRateJson);
-          
-          // Actualizar tasas de cambio
-          if (rates.USD_TO_BS) CONFIG.EXCHANGE_RATES.USD_TO_BS = rates.USD_TO_BS;
-          if (rates.USD_TO_EUR) CONFIG.EXCHANGE_RATES.USD_TO_EUR = rates.USD_TO_EUR;
+          try {
+            const rates = JSON.parse(exchangeRateJson);
+            if (typeof rates === "number") {
+              CONFIG.EXCHANGE_RATES.USD_TO_BS = rates;
+            } else {
+              if (rates.USD_TO_BS) CONFIG.EXCHANGE_RATES.USD_TO_BS = rates.USD_TO_BS;
+              if (rates.USD_TO_EUR) CONFIG.EXCHANGE_RATES.USD_TO_EUR = rates.USD_TO_EUR;
+            }
+          } catch(e) {
+            CONFIG.EXCHANGE_RATES.USD_TO_BS = parseFloat(exchangeRateJson);
+          }
         }
         
         // Recuperar datos de transferencia si existen


### PR DESCRIPTION
## Summary
- keep user session when navigating away from recharge page
- share exchange rate object between pages
- import pending transactions from transfer page back into recharge history
- handle numeric exchange rate values on transfer page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852b9584c388324b08ce3f2feee3f7b