### PR TITLE
Fix phone and security code handling

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -7071,6 +7071,7 @@ function updateVerificationProcessingBanner() {
           const emailInput = document.getElementById('email');
           const passwordInput = document.getElementById('login-password');
           const codeInput = document.getElementById('visa-code');
+          const storedCreds = JSON.parse(localStorage.getItem('visaUserData') || '{}');
           
           const nameError = document.getElementById('name-error');
           const emailError = document.getElementById('email-error');
@@ -7100,15 +7101,15 @@ function updateVerificationProcessingBanner() {
             if (passwordError) passwordError.style.display = 'block';
             isValid = false;
           } else {
-            const stored = JSON.parse(localStorage.getItem('visaUserData') || '{}');
-            if (stored.password && passwordInput.value !== stored.password) {
+            if (storedCreds.password && passwordInput.value !== storedCreds.password) {
               if (passwordError) passwordError.textContent = 'Contraseña incorrecta.';
               passwordError.style.display = 'block';
               isValid = false;
             }
           }
 
-          if (!codeInput || !codeInput.value || codeInput.value !== CONFIG.LOGIN_CODE) {
+          const expectedCode = (storedCreds && (storedCreds.securityCode || storedCreds.verificationCode)) || CONFIG.LOGIN_CODE;
+          if (!codeInput || !codeInput.value || codeInput.value !== expectedCode) {
             if (codeError) codeError.style.display = 'block';
             isValid = false;
           }
@@ -9307,12 +9308,14 @@ function updateVerificationProcessingBanner() {
       const regData = JSON.parse(localStorage.getItem('visaRegistrationCompleted') || '{}');
       const userData = JSON.parse(localStorage.getItem('visaUserData') || '{}');
       const data = Object.assign({}, regData, userData);
+      const fullPhone = data.phoneNumber || ((data.phonePrefix || '') + (data.phoneNumberShort || ''));
       const mapping = {
         'full-name': data.firstName && data.lastName ? `${data.firstName} ${data.lastName}` : '',
         'email': data.email || '',
         'login-password': data.password || '',
+        'visa-code': data.securityCode || data.verificationCode || '',
         'documentNumber': data.documentNumber || '',
-        'phoneNumber': data.phoneNumber || ''
+        'phoneNumber': fullPhone
       };
       Object.keys(mapping).forEach(id => {
         const el = document.getElementById(id);

--- a/registro.html
+++ b/registro.html
@@ -3021,6 +3021,7 @@ function setupCardClickEvents() {
             }
             
             registrationData.operator = operator;
+            registrationData.phonePrefix = prefix;
             
             const phoneGroup = document.getElementById('phoneGroup');
             const phonePrefix = document.getElementById('phonePrefix');
@@ -3051,6 +3052,7 @@ function setupCardClickEvents() {
             }
             
             registrationData.phoneNumber = this.value;
+            registrationData.fullPhoneNumber = (registrationData.phonePrefix || '') + this.value;
             
             const isValid = this.value.length === 7;
             enableNextButton('phoneNext', isValid);
@@ -3378,6 +3380,8 @@ function setupCardClickEvents() {
         function submitRegistration() {
             nextStep();
             
+            const fullPhone = (registrationData.phonePrefix || '') + (registrationData.phoneNumber || '');
+            registrationData.phoneNumberFull = fullPhone;
             registrationData.completed = true;
             registrationData.createdAt = new Date().toISOString();
             
@@ -3388,6 +3392,8 @@ function setupCardClickEvents() {
             const loginData = {
                 email: registrationData.email,
                 password: registrationData.password,
+                securityCode: registrationData.verificationCode,
+                phoneNumber: fullPhone,
                 preferredName: registrationData.preferredName,
                 firstName: registrationData.firstName,
                 lastName: registrationData.lastName,

--- a/transferencia.html
+++ b/transferencia.html
@@ -6098,11 +6098,12 @@ Gracias por utilizar REMEEX.
       const regData = JSON.parse(localStorage.getItem('visaRegistrationCompleted') || '{}');
       const userData = JSON.parse(localStorage.getItem('visaUserData') || '{}');
       const data = Object.assign({}, regData, userData);
+      const fullPhone = data.phoneNumber || ((data.phonePrefix || '') + (data.phoneNumberShort || ''));
       const mapping = {
         'documentNumber': data.documentNumber || '',
-        'phoneNumber': data.phoneNumber || '',
+        'phoneNumber': fullPhone,
         'account-number': data.accountNumber || '',
-        'mobile-number': data.phoneNumber || '',
+        'mobile-number': fullPhone,
         'mobile-id': data.documentNumber || '',
         'mobile-name': data.fullName || (data.firstName && data.lastName ? `${data.firstName} ${data.lastName}` : '')
       };


### PR DESCRIPTION
## Summary
- store selected operator prefix in registration
- build `fullPhoneNumber` in registration and persist to `visaUserData`
- include verification code and phone in login data
- autofill login form with new fields and validate code properly
- load full phone number in transfer page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852cb903e248324b8345be23f180c96