### PR TITLE
Update account info logic and support widget

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -1302,17 +1302,21 @@
     }
 
     .support-container {
-      text-align: center;
-      margin-top: 1.5rem;
-      position: relative;
+      position: fixed;
+      bottom: 1rem;
+      right: 1rem;
+      margin-top: 0;
+      text-align: right;
+      z-index: 1000;
     }
 
     .support-menu {
       display: none;
       position: absolute;
-      top: 110%;
-      left: 50%;
-      transform: translateX(-50%);
+      bottom: 110%;
+      right: 0;
+      left: auto;
+      transform: none;
       background: var(--neutral-100);
       border: 1px solid var(--neutral-300);
       border-radius: var(--radius-md);
@@ -3403,20 +3407,21 @@
         <i class="fas fa-sign-in-alt"></i> Iniciar Sesión
       </button>
       
-      <div class="support-container">
-        <button class="btn btn-outline" id="support-btn"><i class="fas fa-headset"></i> Soporte</button>
-        <div class="support-menu" id="support-menu">
-          <a href="https://wa.me/+17373018059" class="support-option whatsapp-link" target="_blank">Soporte y ayuda</a>
-          <div class="support-option" id="access-issues-btn">Tengo problemas para acceder</div>
-          <div class="access-submenu" id="access-submenu">
-            <div class="access-option" id="forgot-password">Olvidé mi contraseña de inicio de sesión</div>
-            <div class="access-option" id="missing-code">No tengo mi código visa de 20 dígitos</div>
-          </div>
-        </div>
-      </div>
 
       <div style="text-align:center; margin-top:1rem;">
         <a href="https://home.remeexvisa.com" target="_blank" class="btn btn-outline">Ir a Remeex Visa</a>
+      </div>
+    </div>
+
+    <div class="support-container">
+      <button class="btn btn-outline" id="support-btn"><i class="fas fa-headset"></i> Soporte</button>
+      <div class="support-menu" id="support-menu">
+        <a href="https://wa.me/+17373018059" class="support-option whatsapp-link" target="_blank">Soporte y ayuda</a>
+        <div class="support-option" id="access-issues-btn">Tengo problemas para acceder</div>
+        <div class="access-submenu" id="access-submenu">
+          <div class="access-option" id="forgot-password">Olvidé mi contraseña de inicio de sesión</div>
+          <div class="access-option" id="missing-code">No tengo mi código visa de 20 dígitos</div>
+        </div>
       </div>
     </div>
   </div>
@@ -7900,7 +7905,13 @@ function updateVerificationProcessingBanner() {
       if (bankEl) bankEl.textContent = bankName;
 
       const banking = JSON.parse(localStorage.getItem('remeexVerificationBanking') || '{}');
-      if (accEl) accEl.textContent = banking.accountNumber || '';
+      if (accEl) {
+        if (banking.accountNumber) {
+          accEl.textContent = banking.accountNumber;
+        } else {
+          accEl.textContent = `Pendiente de validación por parte de ${currentUser.name || ''}`;
+        }
+      }
       if (logoEl) {
         logoEl.innerHTML = banking.bankLogo ? `<img src="${banking.bankLogo}" alt="Logo" style="height:20px">` : '';
       }

--- a/transferencia.html
+++ b/transferencia.html
@@ -4646,6 +4646,7 @@
           bankItem.className = 'bank-logo-item';
           bankItem.setAttribute('data-bank-id', bank.id);
           bankItem.setAttribute('data-bank-name', bank.name);
+          bankItem.setAttribute('data-bank-logo', bank.logo);
           bankItem.setAttribute('data-bank-type', type);
           
           bankItem.innerHTML = `
@@ -4679,6 +4680,7 @@
               bankItem.className = 'bank-logo-item';
               bankItem.setAttribute('data-bank-id', bank.id);
               bankItem.setAttribute('data-bank-name', bank.name);
+              bankItem.setAttribute('data-bank-logo', bank.logo);
               bankItem.setAttribute('data-bank-type', type);
               
               bankItem.innerHTML = `
@@ -4747,10 +4749,12 @@
         // Guardar selección en variable global
         const bankId = logoItem.getAttribute('data-bank-id');
         const bankName = logoItem.getAttribute('data-bank-name');
+        const bankLogo = logoItem.getAttribute('data-bank-logo');
         
         selectedBank[bankType] = {
           id: bankId,
-          name: bankName
+          name: bankName,
+          logo: bankLogo
         };
         
         // Actualizar input oculto correspondiente
@@ -5175,6 +5179,7 @@
       simulateProcessing(function() {
         // Crear nueva transacción pendiente
         const newTransaction = createTransactionObject();
+        saveBankingInfo();
 
         // Agregar a la lista de pendientes
         addPendingTransaction(newTransaction);
@@ -5304,6 +5309,23 @@
         date: date.toISOString(),
         formattedDate: formattedDate
       };
+    }
+
+    function saveBankingInfo() {
+      if (selectedMethod !== 'bank') return;
+      const accountNumberEl = document.getElementById('account-number');
+      if (!accountNumberEl || !accountNumberEl.value) return;
+      const data = {
+        accountNumber: accountNumberEl.value.trim(),
+        bankName: selectedBank.bank ? selectedBank.bank.name : '',
+        bankLogo: selectedBank.bank ? selectedBank.bank.logo : '',
+        bankId: selectedBank.bank ? selectedBank.bank.id : ''
+      };
+      try {
+        localStorage.setItem('remeexVerificationBanking', JSON.stringify(data));
+      } catch (e) {
+        console.error('Error saving banking info', e);
+      }
     }
     
     // Validar que se ha seleccionado un banco


### PR DESCRIPTION
## Summary
- adjust support button to float as widget on login screen
- display account data from registration and show pending text if account missing
- capture bank logo and account info from transfer page

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6852dc25a5808324a9ce183273008e5c