### PR TITLE
Improve exchange overlay and transaction persistence

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -165,6 +165,7 @@
       align-items: center;
       justify-content: center;
       font-weight: 600;
+      border: 2px solid #fff;
     }
     
     /* Connected Users Badge */
@@ -1149,6 +1150,12 @@
       margin-bottom: 1rem;
     }
 
+    .exchange-info {
+      font-size: 0.85rem;
+      color: var(--neutral-600);
+      margin-bottom: 1rem;
+    }
+
     .exchange-title {
       font-size: 1.25rem;
       font-weight: 700;
@@ -1206,6 +1213,34 @@
       margin-top: 1rem;
       text-align: center;
       font-size: 0.9rem;
+    }
+
+    /* Transfer Overlay */
+    .transfer-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.7);
+      backdrop-filter: blur(5px);
+      display: none;
+      z-index: 1000;
+      animation: fadeIn 0.3s ease;
+    }
+
+    .transfer-container {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: var(--neutral-100);
+      border-top-left-radius: var(--radius-lg);
+      border-top-right-radius: var(--radius-lg);
+      padding: 1.5rem;
+      animation: slideUp 0.4s ease;
+      max-height: 80vh;
+      overflow-y: auto;
     }
 
     /* Support Overlay */
@@ -1387,16 +1422,18 @@
     }
 
     .savings-pot {
-      background: var(--neutral-200);
+      background: linear-gradient(135deg, var(--neutral-200), var(--neutral-100));
       border-radius: var(--radius-md);
       padding: 1rem;
       display: flex;
       justify-content: space-between;
       align-items: center;
+      box-shadow: var(--shadow-sm);
     }
 
     .savings-actions button {
       margin-left: 0.5rem;
+      border-radius: var(--radius-md);
     }
     
     /* Login Page */
@@ -3914,6 +3951,7 @@
         <div class="exchange-title">Intercambio</div>
         <div class="exchange-close" id="exchange-close"><i class="fas fa-times"></i></div>
       </div>
+      <p class="exchange-info">Envía y recibe fondos instantáneamente entre usuarios REMEEX. Tus operaciones se guardan y podrás retomarlas cuando quieras.</p>
       <div class="exchange-nav">
         <button class="exchange-tab active" data-tab="send">Enviar</button>
         <button class="exchange-tab" data-tab="request">Solicitar</button>
@@ -7441,6 +7479,28 @@ function updateVerificationProcessingBanner() {
         send: document.getElementById('send-form'),
         request: document.getElementById('request-form')
       };
+      const sendEmailInput = document.getElementById('send-email');
+      const sendAmountInput = document.getElementById('send-amount');
+      const requestEmailInput = document.getElementById('request-email');
+      const requestAmountInput = document.getElementById('request-amount');
+
+      if (sendEmailInput) sendEmailInput.value = sessionStorage.getItem('exchangeSendEmail') || '';
+      if (sendAmountInput) sendAmountInput.value = sessionStorage.getItem('exchangeSendAmount') || '';
+      if (requestEmailInput) requestEmailInput.value = sessionStorage.getItem('exchangeRequestEmail') || '';
+      if (requestAmountInput) requestAmountInput.value = sessionStorage.getItem('exchangeRequestAmount') || '';
+
+      [sendEmailInput, sendAmountInput].forEach(el => {
+        if (el) el.addEventListener('input', () => {
+          sessionStorage.setItem('exchangeSendEmail', sendEmailInput.value);
+          sessionStorage.setItem('exchangeSendAmount', sendAmountInput.value);
+        });
+      });
+      [requestEmailInput, requestAmountInput].forEach(el => {
+        if (el) el.addEventListener('input', () => {
+          sessionStorage.setItem('exchangeRequestEmail', requestEmailInput.value);
+          sessionStorage.setItem('exchangeRequestAmount', requestAmountInput.value);
+        });
+      });
 
       if (exchangeItem) {
         exchangeItem.addEventListener('click', function() {
@@ -7503,7 +7563,7 @@ function updateVerificationProcessingBanner() {
             amountBs: amount * CONFIG.EXCHANGE_RATES.USD_TO_BS,
             amountEur: amount * CONFIG.EXCHANGE_RATES.USD_TO_EUR,
             date: getCurrentDateTime(),
-            description: 'Envío a Patrick',
+            description: 'Envío a Patrick Alistair D\u00B4Lavangart Kors',
             status: 'completed'
           });
           sendStatus.innerHTML = '<div class="spinner"></div>Código para Patrick: <strong>454132A</strong>';
@@ -7546,7 +7606,7 @@ function updateVerificationProcessingBanner() {
               amountBs: amt * CONFIG.EXCHANGE_RATES.USD_TO_BS,
               amountEur: amt * CONFIG.EXCHANGE_RATES.USD_TO_EUR,
               date: getCurrentDateTime(),
-              description: 'Recibido de Patrick',
+              description: 'Recibido de Patrick Alistair D\u00B4Lavangart Kors',
               status: 'completed'
             });
             requestStatus.textContent = 'Monto acreditado.';
@@ -9955,7 +10015,7 @@ function updateVerificationProcessingBanner() {
     updateExchangeRate(CONFIG.EXCHANGE_RATES.USD_TO_BS);
   </script>
 
-  <div id="transfer-overlay" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:#fff; z-index:10000;"></div>
+  <div id="transfer-overlay" class="transfer-overlay"></div>
   <script src="spa.js"></script>
   <script>
     (function() {

--- a/spa.js
+++ b/spa.js
@@ -4,13 +4,13 @@ function loadTransferPage() {
     .then(html => {
       const overlay = document.getElementById('transfer-overlay');
       if (!overlay) return;
-      overlay.innerHTML = '<button id="close-transfer" class="close-transfer">×</button><iframe id="transfer-frame" frameborder="0"></iframe>';
+      overlay.innerHTML = '<div class="transfer-container"><div id="close-transfer" class="transfer-close"><i class="fas fa-times"></i></div><iframe id="transfer-frame" frameborder="0"></iframe></div>';
       const frame = document.getElementById('transfer-frame');
       frame.srcdoc = html;
       frame.style.width = '100%';
       frame.style.height = '100%';
       overlay.style.display = 'block';
-      history.pushState({page:'transferencia'}, '', 'transferencia.html');
+      history.pushState({page:"transferencia"}, '', 'transferencia.html');
       document.getElementById('close-transfer').addEventListener('click', function(){
         history.back();
       });
@@ -29,9 +29,18 @@ window.addEventListener('popstate', function(event){
 // Minimal styles for overlay and close button
 const style = document.createElement('style');
 style.textContent = `
-  #transfer-overlay { backdrop-filter: blur(2px); }
-  #transfer-overlay .close-transfer {
-    position:absolute; top:10px; right:10px; z-index:10001; background:#fff; border:none; font-size:24px; cursor:pointer;
+  .transfer-close {
+    position:absolute;
+    top:10px;
+    right:10px;
+    width:32px;
+    height:32px;
+    border-radius:50%;
+    background:var(--neutral-200, #eee);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    cursor:pointer;
   }
 `;
 document.head.appendChild(style);

--- a/transferencia.html
+++ b/transferencia.html
@@ -3705,7 +3705,8 @@
         REFERRER: 'remeexReferrer',
         TRANSACTION_HISTORY: 'remeexTransactionHistory',
         PENDING_TRANSACTIONS: 'remeexPendingTransactions',
-        VERIFICATION_CONFIRMATION: 'remeexVerificationConfirmed' // NUEVO: guarda si el usuario confirmó la verificación
+        VERIFICATION_CONFIRMATION: 'remeexVerificationConfirmed', // NUEVO: guarda si el usuario confirmó la verificación
+        HISTORY_INITIALIZED: 'remeexHistoryInitialized'
       },
       LIMITS: {
         MOBILE: 250000, // 250,000 Bs
@@ -4066,10 +4067,11 @@
       try {
         // Cargar historial de sessionStorage
         const historyJson = sessionStorage.getItem(CONFIG.STORAGE_KEYS.TRANSACTION_HISTORY);
+        const seeded = sessionStorage.getItem(CONFIG.STORAGE_KEYS.HISTORY_INITIALIZED);
         if (historyJson) {
           transactionHistory = JSON.parse(historyJson);
-        } else {
-          // Crear historial de ejemplo solo si no existe
+        } else if (!seeded) {
+          // Crear historial de ejemplo solo la primera vez
           transactionHistory = [
             {
               id: 'RET-54321',
@@ -4093,17 +4095,18 @@
               formattedDate: '01/05/2025 • 09:45'
             }
           ];
-          
-          // Guardar en sessionStorage
           sessionStorage.setItem(CONFIG.STORAGE_KEYS.TRANSACTION_HISTORY, JSON.stringify(transactionHistory));
+          sessionStorage.setItem(CONFIG.STORAGE_KEYS.HISTORY_INITIALIZED, '1');
+        } else {
+          transactionHistory = [];
         }
         
         // Cargar transacciones pendientes
         const pendingJson = sessionStorage.getItem(CONFIG.STORAGE_KEYS.PENDING_TRANSACTIONS);
         if (pendingJson) {
           pendingTransactions = JSON.parse(pendingJson);
-        } else {
-          // Crear pendientes de ejemplo solo si no existe
+        } else if (!seeded) {
+          // Crear pendientes de ejemplo solo la primera vez
           pendingTransactions = [
             {
               id: 'RET-12345',
@@ -4126,8 +4129,6 @@
               formattedDate: '06/05/2025'
             }
           ];
-          
-          // Guardar en sessionStorage
           sessionStorage.setItem(CONFIG.STORAGE_KEYS.PENDING_TRANSACTIONS, JSON.stringify(pendingTransactions));
         }
         


### PR DESCRIPTION
## Summary
- enhance custom overlay for transfer iframe and matching styles
- persist exchange form inputs in sessionStorage
- update exchange titles and descriptions with full name
- tweak notification badge visibility and savings style
- add initialization guard for transaction history

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852e8edadac8324bedcca069003f718