### PR TITLE
Improve support button and UI for exchange/savings

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -1155,6 +1155,8 @@
       justify-content: space-between;
       align-items: center;
       margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--neutral-300);
     }
 
     .exchange-info {
@@ -1210,6 +1212,26 @@
       display: none;
       flex-direction: column;
       gap: 0.75rem;
+    }
+
+    .exchange-form input {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      border: 1px solid var(--neutral-400);
+      border-radius: var(--radius-md);
+      font-size: 0.9rem;
+      background: var(--neutral-100);
+      transition: var(--transition-base);
+    }
+
+    .exchange-form input:focus {
+      outline: none;
+      border-color: var(--primary);
+      box-shadow: 0 0 0 3px rgba(26, 31, 113, 0.15);
+    }
+
+    .exchange-form button {
+      width: 100%;
     }
 
     .exchange-form.active {
@@ -1397,6 +1419,8 @@
       justify-content: space-between;
       align-items: center;
       margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--neutral-300);
     }
 
     .savings-title {
@@ -1429,13 +1453,18 @@
     }
 
     .savings-pot {
-      background: linear-gradient(135deg, var(--neutral-200), var(--neutral-100));
-      border-radius: var(--radius-md);
+      background: linear-gradient(135deg, var(--neutral-100), var(--neutral-200));
+      border: 1px solid var(--neutral-300);
+      border-radius: var(--radius-lg);
       padding: 1rem;
       display: flex;
       justify-content: space-between;
       align-items: center;
       box-shadow: var(--shadow-sm);
+    }
+
+    .savings-pot strong {
+      font-size: 0.9rem;
     }
 
     .savings-actions button {
@@ -1519,9 +1548,11 @@
     .support-container {
       position: fixed;
       bottom: 1rem;
-      right: 1rem;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: center;
       margin-top: 0;
-      text-align: right;
       z-index: 1000;
     }
 
@@ -1529,9 +1560,8 @@
       display: none;
       position: absolute;
       bottom: 110%;
-      right: 0;
-      left: auto;
-      transform: none;
+      left: 50%;
+      transform: translateX(-50%);
       background: var(--neutral-100);
       border: 1px solid var(--neutral-300);
       border-radius: var(--radius-md);
@@ -3972,15 +4002,15 @@
         <button class="exchange-tab" data-tab="request">Solicitar</button>
       </div>
       <div class="exchange-form active" id="send-form">
-        <input type="email" id="send-email" placeholder="Email del destinatario">
-        <input type="number" id="send-amount" min="50" max="1000" placeholder="Monto (USD)">
-        <button id="send-money-btn">Enviar</button>
+        <input type="email" class="form-control" id="send-email" placeholder="Email del destinatario">
+        <input type="number" class="form-control" id="send-amount" min="50" max="1000" placeholder="Monto (USD)">
+        <button class="btn btn-primary" id="send-money-btn">Enviar</button>
         <div class="exchange-status" id="send-status"></div>
       </div>
       <div class="exchange-form" id="request-form">
-        <input type="email" id="request-email" placeholder="Email del usuario">
-        <input type="number" id="request-amount" min="50" max="1000" placeholder="Monto (USD)">
-        <button id="request-money-btn">Solicitar</button>
+        <input type="email" class="form-control" id="request-email" placeholder="Email del usuario">
+        <input type="number" class="form-control" id="request-amount" min="50" max="1000" placeholder="Monto (USD)">
+        <button class="btn btn-primary" id="request-money-btn">Solicitar</button>
         <div class="exchange-status" id="request-status"></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- center support button on login screen
- style exchange forms and buttons
- polish savings pot styles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685306767c38832486fee37fa8de3772